### PR TITLE
[proposal] Make explicit that __MODULE__'s value changes when inside definst/3

### DIFF
--- a/lib/type_class.ex
+++ b/lib/type_class.ex
@@ -165,6 +165,50 @@ defmodule TypeClass do
         def concat(a, b), do: a ++ b
       end
 
+  ## `__MODULE__`'s meaning changes inside `definst`
+
+  Beware  that   the  value  of   `__MODULE__`  inside
+  `definst`  will   be  different  from   the  outside
+  context:  `definst`'s  `do`  block will  be  invoked
+  inside `defimpl` macro's body, and `defimpl` creates
+  its own container module to run things in.
+
+  For example, the code below won't compile:
+
+      defmodule Name do
+        import Algae
+        import TypeClass
+        use Witchcraft
+
+        defdata do
+          name :: String.t()
+        end
+
+        definst Witchcraft.Functor, for: __MODULE__ do
+          @force_type_instance true
+
+          def map(%__MODULE__{name: name}, f) do
+            __MODULE__.new(name)
+          end
+        end
+      end
+
+      # ** (CompileError) lib/instance/assword.ex:13:
+      #    Witchcraft.Functor.Proto.Instance.Name.__struct__/0 is undefined,
+      #    cannot expand struct Witchcraft.Functor.Proto.Instance.Name
+
+  Either use the full module name, or `alias` it, if
+  too long, such as
+
+      defmodule Name do
+        # (...)
+        # here
+
+        definst Witchcraft.Functor, for: __MODULE__ do
+          # or here
+          # (...)
+        end
+      end
   """
   defmacro definst(class, opts, do: body) do
     [for: datatype] = opts

--- a/lib/type_class.ex
+++ b/lib/type_class.ex
@@ -169,14 +169,23 @@ defmodule TypeClass do
   defmacro definst(class, opts, do: body) do
     [for: datatype] = opts
 
+    # __MODULE__ == TypeClass
+
     quote do
       instance = Module.concat([unquote(class), Proto, unquote(datatype)])
+
+      # __MODULE__ == datatype
+      datatype_module = unquote(datatype)
 
       defimpl unquote(class).Proto, for: unquote(datatype) do
         import TypeClass.Property.Generator.Custom
 
+        # __MODULE__ == class.Proto.datatype
         Module.register_attribute(__MODULE__, :force_type_instance, [])
         @force_type_instance false
+
+        Module.register_attribute(__MODULE__, :datatype, [])
+        @datatype datatype_module
 
         @doc false
         def __custom_generator__, do: false


### PR DESCRIPTION
Calling `definst/3`'s  body inside  `defimpl` breaks the semantics  of `__MODULE__`  (is this  the proper way to say it?).

For example,

```elixir
defmodule Name do
  import Algae
  import TypeClass
  use Witchcraft

  defdata do
    name :: String.t()
  end

  definst Witchcraft.Functor, for: __MODULE__ do
    @force_type_instance true

    def map(%__MODULE__{name: name}, f) do
      __MODULE__.new(name)
    end
  end
end
```

will result in

```
** (CompileError) lib/instance/assword.ex:13: 
Witchcraft.Functor.Proto.Instance.Name.__struct__/0 is undefined, 
cannot expand struct Witchcraft.Functor.Proto.Instance.Name
```

I know that `map/2` above could've been defined as

```elixir
def map(%{name: name}), do: Name.new(name)
```

or a long name could be `alias`ed, but it is not intuitive, and I don't think this behaviour is documented. (That is, I remember some mention of it, but couldn't find that passage again.)

---

The two commits below are just suggestions: 
* 16f7857 - add a module attribute
* ad4fbbb - make this behaviour explicit in docs
