### PR TITLE
Remove TypeClass.Utility.Module.append/2

### DIFF
--- a/lib/type_class/property.ex
+++ b/lib/type_class/property.ex
@@ -20,14 +20,14 @@ defmodule TypeClass.Property do
   @doc "Run all properties for the type class"
   @spec run!(module(), module(), atom(), non_neg_integer()) :: no_return()
   def run!(datatype, class, prop_name, times \\ 100) do
-    property_module = TC.append(class, Property)
+    property_module = Module.concat(class, Property)
     custom_generator = Module.concat([class, "Proto", datatype]).__custom_generator__()
 
     data_generator =
       if custom_generator do
         custom_generator
       else
-        TC.append(TypeClass.Property.Generator, datatype).generate(nil)
+        Module.concat(TypeClass.Property.Generator, datatype).generate(nil)
       end
 
     fn ->

--- a/lib/type_class/utility/module.ex
+++ b/lib/type_class/utility/module.ex
@@ -87,11 +87,4 @@ defmodule TypeClass.Utility.Module do
       :extract_protocols
     ])
   end
-
-  def append(parent_module, submodule) do
-    parent_module
-    |> Module.split()
-    |> (fn modules -> modules ++ List.wrap(submodule) end).()
-    |> Module.concat()
-  end
 end


### PR DESCRIPTION
Its functionality seems to be redundant with `Module.concat/2`, and has only been used in the`TypeClass.Property` module.

There are not tests in `TypeClass`, but I created a mix project, and added `Algae` as a dependency which compiled without any issue. Tried out the below snippet as well, no problems:

```elixir
defmodule Name do
  import Algae
  import TypeClass
  use Witchcraft
  alias __MODULE__, as: N

  defdata do
    name :: String.t()
  end

  definst Witchcraft.Functor, for: __MODULE__ do
    @force_type_instance true
    def map(%{name: name}, f) do
      N.new(f.(name))
    end
  end

  def add_title(%__MODULE__{} = name, title) do
    name ~> &Kernel.<>(title, &1)
  end
end
```